### PR TITLE
Add unit and integration tests for RAG services

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+@pytest.fixture
+def mock_db():
+    """Return a simple mocked database session."""
+    db = MagicMock()
+    return db
+
+@pytest.fixture
+def patch_get_vector_db(mock_db):
+    with patch('app.db.connection.get_vector_db', return_value=mock_db):
+        yield mock_db

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import MagicMock
+from RAG.services.embedding_services import EmbeddingService
+
+class DummyEmbeddingResponse:
+    def __init__(self, embeddings):
+        self.data = [MagicMock(embedding=e) for e in embeddings]
+
+@pytest.mark.asyncio
+async def test_create_embedding(monkeypatch):
+    service = EmbeddingService()
+    response = DummyEmbeddingResponse([[0.1, 0.2]])
+    service.client.embeddings.create = MagicMock(return_value=response)
+
+    result = await service.create_embedding("hello")
+    assert result == [0.1, 0.2]
+
+@pytest.mark.asyncio
+async def test_batch_create_embedding(monkeypatch):
+    service = EmbeddingService()
+    embeddings = [[0.1, 0.2], [0.3, 0.4]]
+    response = DummyEmbeddingResponse(embeddings)
+    service.client.embeddings.create = MagicMock(return_value=response)
+
+    result = await service.batch_create_embedding(["a", "b"])
+    assert result == embeddings

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,0 +1,28 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from RAG.db.vector_store import VectorStore
+from RAG.services.synthesizer import Synthesizer
+from app.schemas.transferPlanRequest import TransferPlanRequest
+
+@pytest.mark.asyncio
+async def test_search_and_synthesize(patch_get_vector_db):
+    mock_db = patch_get_vector_db
+    first_call = MagicMock()
+    first_call.fetchall.return_value = [
+        (1, "content1", "college", "uni", "major", "course_des", 0.9)
+    ]
+    second_call = MagicMock()
+    second_call.fetchall.return_value = []
+    mock_db.execute.side_effect = [first_call, second_call]
+
+    with patch('RAG.services.embedding_services.EmbeddingService.create_embedding', return_value=[0.1]*1536):
+        store = VectorStore()
+        results = await store.vector_search("query", TransferPlanRequest(college_id=1, university_id=1, major_id=1))
+
+    synth = Synthesizer()
+    synth.client.chat.completions.create = MagicMock(return_value=MagicMock(
+        choices=[MagicMock(message=MagicMock(content='{"res": 1}'))]
+    ))
+    response = await synth.generate_response("query", results)
+
+    assert response == {"res": 1}

--- a/tests/test_knowledge_chunker.py
+++ b/tests/test_knowledge_chunker.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import MagicMock
+from RAG.services.knowledge_chunker import KnowledgeChunker
+from app.db.models.courses import Courses
+from app.db.models.colleges import Colleges
+
+@pytest.fixture
+def db_mock():
+    db = MagicMock()
+    course = MagicMock(spec=Courses)
+    course.code = "CS101"
+    course.name = "Intro"
+    course.units = 3
+    course.difficulty = 5
+
+    college = MagicMock(spec=Colleges)
+    college.id = 1
+    college.college_name = "Test College"
+
+    db.query.return_value.join.return_value.all.return_value = [(course, college)]
+    return db
+
+@pytest.mark.asyncio
+async def test_generate_course_chunker(db_mock):
+    chunker = KnowledgeChunker()
+    chunks = await chunker.generate_course_chunker(db_mock)
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk["college_id"] == 1
+    assert chunk["chunk_type"] == "course_description"

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import MagicMock
+from RAG.services.synthesizer import Synthesizer
+
+class DummyChatResponse:
+    def __init__(self, content):
+        self.choices = [MagicMock(message=MagicMock(content=content))]
+
+@pytest.mark.asyncio
+async def test_vector_result_to_json():
+    synth = Synthesizer()
+    data = [{"id": 1, "content": "hello"}]
+    json_result = await synth.vector_result_to_json(data)
+    assert "hello" in json_result
+
+@pytest.mark.asyncio
+async def test_generate_response(monkeypatch):
+    synth = Synthesizer()
+    synth.client.chat.completions.create = MagicMock(return_value=DummyChatResponse('{"answer": "ok"}'))
+    result = await synth.generate_response("hi", [])
+    assert result == {"answer": "ok"}

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from RAG.db.vector_store import VectorStore
+from app.schemas.transferPlanRequest import TransferPlanRequest
+
+@pytest.mark.asyncio
+async def test_vector_search(patch_get_vector_db):
+    mock_db = patch_get_vector_db
+    first_call = MagicMock()
+    first_call.fetchall.return_value = [
+        (1, "content1", "college", "uni", "major", "course_des", 0.9)
+    ]
+    second_call = MagicMock()
+    second_call.fetchall.return_value = []
+    mock_db.execute.side_effect = [first_call, second_call]
+
+    with patch('RAG.services.embedding_services.EmbeddingService.create_embedding', return_value=[0.1]*1536):
+        store = VectorStore()
+        results = await store.vector_search("query", TransferPlanRequest(college_id=1, university_id=1, major_id=1))
+
+    assert len(results) == 1
+    assert results[0]['content'] == 'content1'


### PR DESCRIPTION
## Summary
- create new test suite under `tests` for the RAG services
- add fixtures that mock database access
- add unit tests for EmbeddingService, Synthesizer, KnowledgeChunker and VectorStore
- add integration test covering vector search and synthesis pipeline

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.115.12)*
- `pytest -q tests` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686332b6a524833089ce4e2f5d191a7e